### PR TITLE
Add placeholder visionModel functions

### DIFF
--- a/src/visionModel.py
+++ b/src/visionModel.py
@@ -1,0 +1,11 @@
+from PIL import Image
+
+
+def getPredictionJson(image_path, threshold=0):
+    """Return an empty dict as a placeholder for future model predictions."""
+    return {}
+
+
+def getPredictionLabels(image_path, threshold=0):
+    """Return the image opened with PIL as a placeholder for labeled output."""
+    return Image.open(image_path)


### PR DESCRIPTION
## Summary
- stub out `getPredictionJson` and `getPredictionLabels`

## Testing
- `python -m py_compile src/visionModel.py`


------
https://chatgpt.com/codex/tasks/task_e_6859830830888330ac9a3aa2406329e4