### PR TITLE
Add pytest and distance test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ networkx
 numpy
 pandas
 pyarrow
+pytest
+shapely
+opencv-python-headless

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,0 +1,29 @@
+import os, sys, types
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, BASE_DIR)
+sys.path.insert(0, os.path.join(BASE_DIR, "src"))
+
+import PIL.ImageFont
+PIL.ImageFont.truetype = lambda *a, **kw: None
+# Stub visionModel module required by app.py
+visionModel = types.ModuleType("visionModel")
+visionModel.getPredictionJson = lambda *args, **kwargs: None
+visionModel.getPredictionLabels = lambda *args, **kwargs: None
+sys.modules["visionModel"] = visionModel
+
+import pytest
+from app import calculate_distance
+
+
+def test_zero_distance():
+    coord = (37.7749, -122.4194)
+    assert calculate_distance(coord, coord) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_known_distance():
+    coord1 = (0.0, 0.0)
+    coord2 = (0.0, 1.0)  # 1 degree east at equator
+    distance = calculate_distance(coord1, coord2)
+    assert distance == pytest.approx(111194.9266, rel=1e-4)
+
+


### PR DESCRIPTION
## Summary
- add pytest dependency
- stub modules to import `calculate_distance`
- test `calculate_distance` for zero and known distances

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859831210a88330946a0e3707925010