### PR TITLE
Improve initial POC experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@
 Leveraging graph analysis and simulation, this project aims to predict the best shots and club selections for each hole on a golf course. 
 
 Ideal for golfers looking to enhance their game and developers interested in sports applications of AI. ⛳🤖
+
+## Getting Started
+
+1. **Install dependencies**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Run the unit tests** (optional)
+
+   ```bash
+   pytest
+   ```
+
+3. **Launch the demo**
+
+   ```bash
+   cd src
+   python app.py
+   ```
+
+   The script will ask you to choose a course ("1" for Béthemont or "2" for Ilbarritz) and then generate annotated images inside `src/output/`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pyarrow
 pytest
 shapely
 opencv-python-headless
+Pillow

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ import numpy as np
 import networkx as nx
 import matplotlib.pyplot as plt
 from matplotlib.patches import Polygon, Ellipse
+import os
 from PIL import Image, ImageDraw, ImageFont
 from shapely.geometry import LineString, Polygon
 import cv2
@@ -15,7 +16,8 @@ from GoogleMapDownloader import GoogleMapDownloader, GoogleMapsLayers
 from visionModel import getPredictionJson, getPredictionLabels
 
 # Some settings for the PIL package
-font = ImageFont.truetype("../fonts/RobotoMono-Bold.ttf", 30)
+FONT_PATH = os.path.join(os.path.dirname(__file__), "..", "fonts", "RobotoMono-Bold.ttf")
+font = ImageFont.truetype(FONT_PATH, 30)
 
 # Don't mind this 🤡
 global golf_irons 
@@ -231,10 +233,12 @@ if __name__ == "__main__":
     img_path = "output/image.png"
     img.save(img_path)
 
-    # Show the prediction on the image (the returned image is a cv2 image)
+    # Show the prediction on the image and save it
     img_with_labels = getPredictionLabels(img_path, threshold=value_threshold)
-    # Save the image
-    cv2.imwrite("output/image_with_labels.png", img_with_labels)
+    if isinstance(img_with_labels, Image.Image):
+        img_with_labels.save("output/image_with_labels.png")
+    else:
+        cv2.imwrite("output/image_with_labels.png", img_with_labels)
 
     # Define the geographical extent and image size
     corners = gmd.get_corner_lat_lons()
@@ -298,7 +302,7 @@ if __name__ == "__main__":
 
 
     # Optionally, draw obstacles based on a flag
-    draw_obstacles = False
+    draw_obstacles = True
     if draw_obstacles:
         with open(obstacles_file, "r") as file:
             for line in file:

--- a/src/visionModel.py
+++ b/src/visionModel.py
@@ -1,4 +1,8 @@
+"""Very lightweight vision utilities used by app.py."""
+
 from PIL import Image
+import cv2
+import numpy as np
 
 
 def getPredictionJson(image_path, threshold=0):
@@ -6,6 +10,36 @@ def getPredictionJson(image_path, threshold=0):
     return {}
 
 
-def getPredictionLabels(image_path, threshold=0):
-    """Return the image opened with PIL as a placeholder for labeled output."""
-    return Image.open(image_path)
+def getPredictionLabels(image_path, threshold=500):
+    """Perform a naive blue color segmentation and draw contours.
+
+    Parameters
+    ----------
+    image_path: str
+        Path to the image on which to run the segmentation.
+    threshold: int, optional
+        Minimum contour area (in pixels) to be drawn.  This keeps the
+        output relatively clean.
+
+    Returns
+    -------
+    numpy.ndarray
+        The annotated image in OpenCV's BGR format.
+    """
+
+    image = cv2.imread(image_path)
+    if image is None:
+        # Fallback: return the raw image opened with PIL
+        return np.array(Image.open(image_path))
+
+    hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+    lower_blue = np.array([100, 50, 50])
+    upper_blue = np.array([140, 255, 255])
+    mask = cv2.inRange(hsv, lower_blue, upper_blue)
+
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    for cnt in contours:
+        if cv2.contourArea(cnt) >= threshold:
+            cv2.drawContours(image, [cnt], -1, (0, 0, 255), 2)
+
+    return image


### PR DESCRIPTION
## Summary
- implement a tiny vision model that highlights blue regions
- fix PIL/NumPy image handling when saving predictions
- resolve font path using absolute path
- draw course obstacles by default
- add Pillow dependency
- document how to run a quick demo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867957b34f883308085fc108e4ea722